### PR TITLE
DPS-1847: Make sendEmails more transparent by returning emails processed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,9 @@ val root = Project(id = moduleName, base = file("."))
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 resolvers ++= Seq(
-  "Artifactory Snapshot Realm" at "http://artifactory.registered-traveller.homeoffice.gov.uk/artifactory/libs-snapshot-local/",
-  "Artifactory Release Realm" at "http://artifactory.registered-traveller.homeoffice.gov.uk/artifactory/libs-release-local/",
-  "Artifactory External Release Local Realm" at "http://artifactory.registered-traveller.homeoffice.gov.uk/artifactory/ext-release-local/"
+  "Artifactory Snapshot Realm" at "https://artifactory.digital.homeoffice.gov.uk/artifactory/libs-snapshot-local/",
+  "Artifactory Release Realm" at "https://artifactory.digital.homeoffice.gov.uk/artifactory/libs-release-local/",
+  "Artifactory External Release Local Realm" at "https://artifactory.digital.homeoffice.gov.uk/artifactory/ext-release-local/"
 )
 
 libraryDependencies ++= Seq(
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
 )
 
 publishTo := {
-  val artifactory = sys.env.get("ARTIFACTORY_SERVER").getOrElse("http://artifactory.registered-traveller.homeoffice.gov.uk/")
+  val artifactory = sys.env.get("ARTIFACTORY_SERVER").getOrElse("https://artifactory.digital.homeoffice.gov.uk/")
   Some("release"  at artifactory + "artifactory/libs-release-local")
 }
 

--- a/src/test/scala/cjp/emailer/EmailerSpec.scala
+++ b/src/test/scala/cjp/emailer/EmailerSpec.scala
@@ -17,17 +17,18 @@ class EmailerSpec extends Specification with Mockito {
     val sender = EmailAddress("", "")
     val replyTo = EmailAddress("", "")
     val emailer = new Emailer(emailRepository, emailSender, sender, Some(replyTo), 5, processLockRepository)
-    val PROVISIONAL_ACCEPTANCE = "PROVISIONAL_ACCEPTANCE"  
+    val PROVISIONAL_ACCEPTANCE = "PROVISIONAL_ACCEPTANCE"
   }
-  
+
   "Emailer" should {
     "sendEmails zero emails if no emails in queue" in new Context {
       emailRepository.findByStatus(STATUS_WAITING) returns List()
 
-      emailer.sendEmails()
+      val result = emailer.sendEmails()
 
       there was no(emailSender).sendMessage(any, anyString, any[List[String]], anyString, anyString, any, any, any)
       there was no(emailRepository).updateStatus(anyString, any)
+      result mustEqual List.empty
     }
 
     "sendEmails should send an email and set the status to sent for all emails in the queue" in new Context {
@@ -56,10 +57,11 @@ class EmailerSpec extends Specification with Mockito {
       val emailList = List(emailObj1, emailObj2)
       emailRepository.findByStatus(STATUS_WAITING) returns emailList
 
-      emailer.sendEmails()
+      val result = emailer.sendEmails()
 
       there were two(emailSender).sendMessage(any, anyString, any[List[String]], anyString, any, any, any, any)
       there were two(emailRepository).updateStatus(anyString, any)
+      result mustEqual List((emailObj1, STATUS_SENT), (emailObj2, STATUS_SENT))
     }
   }
 }


### PR DESCRIPTION
This doesn't change the way errors are handled or any of the logic. It just makes the function return a list of emails and their new status, instead of Unit. This is so I can extract those metrics and pass them to sysdig in evw-integration-service.